### PR TITLE
Changed apt-get sources file location

### DIFF
--- a/agent_setup.sh
+++ b/agent_setup.sh
@@ -269,7 +269,7 @@ _software_agent()(
     # Add the NetBeez software repository, update the database, and install the netbeez-agent package:
     log "ADDING netbeez repos and installing netbeez software"
     echo "deb [arch=amd64] http://repo.netbeez.net wheezy main" | \
-      tee -a /etc/apt/sources.list
+      tee /etc/apt/sources.list.d/netbeez.list
     wget -O - http://repo.netbeez.net/netbeez_pub.key | \
       apt-key add -
     apt-get update


### PR DESCRIPTION
Changed from /etc/apt/sources.list to a separate, by-itself, /etc/apt/sources.list.d/netbeez.list file.

This way, you can take out the `-a` flag, thus stopping all accidental duplications of the repo.netbeez line, stopping any errors in apt-get updates.

Plus, its just nicer having the "outside-of-main" repo's in their own lists.