### PR TITLE
Support Debian Buster and Ubuntu Bionic

### DIFF
--- a/agent_setup.sh
+++ b/agent_setup.sh
@@ -668,11 +668,11 @@ function get_debian_codename(){
     local -r codename=$(
         if [[ "${os_id}" == "ubuntu" ]]; then
             awk -F/ '{print $1}' "/etc/debian_version" \
-            | sed s/stretch/wheezy/
+            | sed s/stretch/wheezy/ | sed s/buster/stretch/
         else
             lsb_release --codename --short
         fi \
-        | sed s/jessie/wheezy/ 
+        | sed s/jessie/wheezy/ | sed s/buster/stretch/ 
     )
     ## note: use wheezy source on jessie installs
 


### PR DESCRIPTION
These changes use the stretch version for Debian Buster and Ubuntu Bionic. They have been tested and fix the installation problem with those distributions.