### PR TITLE
fix(setup): model file is detected as binary by grep.

### DIFF
--- a/agent_setup.sh
+++ b/agent_setup.sh
@@ -381,9 +381,9 @@ function is_rpi_wifi_agent(){
 
     local status="false"
 
-    if [[ -f "${model_file}" && $(cat "${model_file}" | grep "${rpi_3_model}") ]]; then
+    if [[ -f "${model_file}" && $(cat "${model_file}" | grep -a "${rpi_3_model}") ]]; then
         status="true"
-    elif [[ -f "${model_file}" && $(cat "${model_file}" | grep "${rpi_4_model}") ]]; then
+    elif [[ -f "${model_file}" && $(cat "${model_file}" | grep -a "${rpi_4_model}") ]]; then
         status="true"
     fi
 


### PR DESCRIPTION
Quick fix to detect properly the model of the hardware.